### PR TITLE
feat(enc-additional-data): encript additional data as part for the jwe token

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/title_activity_main">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/sdk/src/main/java/io/hellgate/android/sdk/client/hellgate/HgClient.kt
+++ b/sdk/src/main/java/io/hellgate/android/sdk/client/hellgate/HgClient.kt
@@ -5,8 +5,6 @@ import io.hellgate.android.sdk.client.*
 import io.hellgate.android.sdk.client.hellgate.Segments.COMPLETE_ACTION
 import io.hellgate.android.sdk.client.hellgate.Segments.SESSIONS
 import io.hellgate.android.sdk.client.hellgate.SessionCompleteTokenizeCard.*
-import io.hellgate.android.sdk.client.hellgate.SessionCompleteTokenizeCard.AdditionalData.Companion.toDTO
-import io.hellgate.android.sdk.element.additionaldata.AdditionalDataTypes
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpMethod
 import java.io.Closeable
@@ -22,7 +20,6 @@ internal interface HgClient : Closeable {
     suspend fun completeTokenizeCard(
         sessionId: String,
         encryptedData: String,
-        additionalData: Map<AdditionalDataTypes, String>,
     ): Either<HttpClientError, SessionResponse>
 }
 
@@ -44,17 +41,13 @@ internal fun hgClient(
     override suspend fun completeTokenizeCard(
         sessionId: String,
         encryptedData: String,
-        additionalData: Map<AdditionalDataTypes, String>,
     ): Either<HttpClientError, SessionResponse> =
         client.eitherRequest<SessionResponse, SessionCompleteTokenizeCard>(
             HttpMethod.Post,
             baseUrl,
             listOf(SESSIONS, sessionId, COMPLETE_ACTION),
             body = SessionCompleteTokenizeCard(
-                result = Result(
-                    encryptedData,
-                    if (additionalData.isEmpty()) null else additionalData.toDTO(),
-                ),
+                result = Result(encryptedData),
             ),
         )
 }

--- a/sdk/src/main/java/io/hellgate/android/sdk/client/hellgate/Session.kt
+++ b/sdk/src/main/java/io/hellgate/android/sdk/client/hellgate/Session.kt
@@ -2,7 +2,6 @@ package io.hellgate.android.sdk.client.hellgate
 
 import com.fasterxml.jackson.annotation.*
 import com.fasterxml.jackson.databind.JsonNode
-import io.hellgate.android.sdk.element.additionaldata.AdditionalDataTypes
 
 internal data class SessionResponse(
     val data: Data?,
@@ -37,15 +36,5 @@ internal data class SessionCompleteTokenizeCard(
 ) {
     data class Result(
         val encPayload: String,
-        val additionalData: AdditionalData?,
     )
-
-    data class AdditionalData(
-        @JsonProperty("cardholder_name")
-        val cardholderName: String?,
-    ) {
-        companion object {
-            fun Map<AdditionalDataTypes, String>.toDTO() = AdditionalData(this[AdditionalDataTypes.CARDHOLDER_NAME])
-        }
-    }
 }

--- a/sdk/src/main/java/io/hellgate/android/sdk/element/additionaldata/AdditionalDataTypes.kt
+++ b/sdk/src/main/java/io/hellgate/android/sdk/element/additionaldata/AdditionalDataTypes.kt
@@ -1,6 +1,6 @@
 package io.hellgate.android.sdk.element.additionaldata
 
-enum class AdditionalDataTypes(internal val label: String) {
+enum class AdditionalDataTypes(private val label: String) {
     CARDHOLDER_NAME("Cardholder Name"),
     EMAIL("E-Mail"),
     BILLING_ADDRESS_LINE_1("Billing Address Line 1"),
@@ -12,4 +12,6 @@ enum class AdditionalDataTypes(internal val label: String) {
     ;
 
     fun getLabel(): String = label
+
+    internal fun getSerializeName(): String = name.lowercase()
 }

--- a/sdk/src/main/java/io/hellgate/android/sdk/handler/CardHandler.kt
+++ b/sdk/src/main/java/io/hellgate/android/sdk/handler/CardHandler.kt
@@ -36,7 +36,8 @@ internal fun cardHandler(
         return tokenService.tokenize(
             sessionId,
             cardData,
-            additionalData.associate { it.additionalDataTypes to it.value() },
+            additionalData.associate { it.additionalDataTypes to it.value() }
+                .filter { it.value.isNotBlank() },
         )
     }
 

--- a/sdk/src/main/java/io/hellgate/android/sdk/service/EncryptedTokenizeRequest.kt
+++ b/sdk/src/main/java/io/hellgate/android/sdk/service/EncryptedTokenizeRequest.kt
@@ -8,6 +8,7 @@ import com.nimbusds.jose.crypto.RSAEncrypter
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jwt.EncryptedJWT
 import com.nimbusds.jwt.JWTClaimsSet
+import io.hellgate.android.sdk.element.additionaldata.AdditionalDataTypes
 import io.hellgate.android.sdk.model.CardData
 import io.hellgate.android.sdk.util.jsonSerialize
 
@@ -17,16 +18,20 @@ internal typealias JWE = String
 
 internal fun createJWE(
     cardData: CardData,
+    additionalData: Map<AdditionalDataTypes, String>,
     jwk: JsonNode,
 ): JWE {
     val header = JWEHeader(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
     val claims = JWTClaimsSet.Builder()
-        .claim("expiry_month", cardData.month.toInt())
-        .claim("expiry_year", cardData.year.toInt() + BASE_YEAR)
-        .claim("account_number", cardData.cardNumber)
-        .claim("security_code", cardData.cvc)
-        // TODO add additional data
-        // .claim("additional_data", mapOf("cardholder_name" to "John Doe"))
+        .apply {
+            claim("expiry_month", cardData.month.toInt())
+            claim("expiry_year", cardData.year.toInt() + BASE_YEAR)
+            claim("account_number", cardData.cardNumber)
+            claim("security_code", cardData.cvc)
+        }
+        .apply {
+            additionalData.forEach { (type, value) -> claim(type.getSerializeName(), value) }
+        }
         .build()
 
     val jwt = EncryptedJWT(header, claims)

--- a/sdk/src/main/java/io/hellgate/android/sdk/service/TokenService.kt
+++ b/sdk/src/main/java/io/hellgate/android/sdk/service/TokenService.kt
@@ -43,15 +43,15 @@ internal fun tokenService(
             either {
                 resourceScope {
                     val hgClient = closeable { hellgateClient() }
-                    val info = hgClient.fetchSession(sessionId).bind()
+                    val session = hgClient.fetchSession(sessionId).bind()
 
-                    ensure(info.nextAction == NextAction.TOKENIZE_CARD) { failed() }
-                    ensure(info.data != null) { failed() }
-                    ensure(info.data is SessionResponse.Data.TokenizationParam) { failed() }
+                    ensure(session.nextAction == NextAction.TOKENIZE_CARD) { failed() }
+                    ensure(session.data != null) { failed() }
+                    ensure(session.data is SessionResponse.Data.TokenizationParam) { failed() }
 
-                    val encryptedData = createJWE(cardData, info.data.jwk)
+                    val encryptedData = createJWE(cardData, additionalData, session.data.jwk)
 
-                    val result = hgClient.completeTokenizeCard(sessionId, encryptedData, additionalData).bind()
+                    val result = hgClient.completeTokenizeCard(sessionId, encryptedData).bind()
                     ensure(result.status == SUCCESS) { failed() }
                     ensure(result.data != null) { failed() }
                     ensure(result.data is SessionResponse.Data.TokenId) { failed() }

--- a/sdk/src/test/java/io/hellgate/android/sdk/client/hellgate/HgClientKtTest.kt
+++ b/sdk/src/test/java/io/hellgate/android/sdk/client/hellgate/HgClientKtTest.kt
@@ -5,7 +5,6 @@ import arrow.fx.coroutines.resourceScope
 import io.hellgate.android.sdk.TestFactory.JWK
 import io.hellgate.android.sdk.TestFactory.TOKENIZE_CARD_RESPONSE
 import io.hellgate.android.sdk.client.HttpClientError
-import io.hellgate.android.sdk.element.additionaldata.AdditionalDataTypes
 import io.hellgate.android.sdk.testutil.*
 import io.hellgate.android.sdk.util.jsonDeserialize
 import kotlinx.coroutines.test.runTest
@@ -53,7 +52,7 @@ class HgClientKtTest {
 
             resourceScope {
                 val hgClient = closeable { hgClient(baseUrl) }
-                val result = hgClient.completeTokenizeCard("123", "token_123", emptyMap())
+                val result = hgClient.completeTokenizeCard("123", "token_123")
 
                 result.assertRight {
                     assertThat(it).isEqualTo(SessionResponse(SessionResponse.Data.TokenId("eaac6eac-6d09-469b-a981-f1be82b155f9"), null, "success"))
@@ -67,7 +66,7 @@ class HgClientKtTest {
 
             resourceScope {
                 val hgClient = closeable { hgClient(baseUrl) }
-                val result = hgClient.completeTokenizeCard("123", "token_123", mapOf(AdditionalDataTypes.CARDHOLDER_NAME to "John Doe"))
+                val result = hgClient.completeTokenizeCard("123", "token_123")
 
                 result.assertRight {
                     assertThat(it).isEqualTo(SessionResponse(SessionResponse.Data.TokenId("eaac6eac-6d09-469b-a981-f1be82b155f9"), null, "success"))
@@ -81,7 +80,7 @@ class HgClientKtTest {
 
             resourceScope {
                 val hgClient = closeable { hgClient(baseUrl) }
-                val result = hgClient.completeTokenizeCard("404", "token_123", emptyMap())
+                val result = hgClient.completeTokenizeCard("404", "token_123")
 
                 result.assertLeft {
                     assertThat(it).isEqualTo(HttpClientError("404 Not Found : {\"code\":404,\"message\":\"The session_context was not found\",\"classifier\":\"NOT_FOUND\"}", null))

--- a/sdk/src/test/java/io/hellgate/android/sdk/element/additionaldata/AdditionalDataTypesTest.kt
+++ b/sdk/src/test/java/io/hellgate/android/sdk/element/additionaldata/AdditionalDataTypesTest.kt
@@ -1,13 +1,17 @@
 package io.hellgate.android.sdk.element.additionaldata
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class AdditionalDataTypesTest {
     @Test
     fun getLabel() {
-        AdditionalDataTypes.entries.forEach {
-            Assertions.assertThat(it.getLabel()).isNotEmpty().isEqualTo(it.label)
-        }
+        assertThat(AdditionalDataTypes.EMAIL.getLabel()).isNotEmpty().isEqualTo("E-Mail")
+    }
+
+    @Test
+    fun getSerializeName() {
+        assertThat(AdditionalDataTypes.CARDHOLDER_NAME.getSerializeName()).isEqualTo("cardholder_name")
+        assertThat(AdditionalDataTypes.EMAIL.getSerializeName()).isEqualTo("email")
     }
 }

--- a/sdk/src/test/java/io/hellgate/android/sdk/service/TokenServiceKtTest.kt
+++ b/sdk/src/test/java/io/hellgate/android/sdk/service/TokenServiceKtTest.kt
@@ -8,7 +8,6 @@ import io.hellgate.android.sdk.Constants
 import io.hellgate.android.sdk.client.HttpClientError
 import io.hellgate.android.sdk.client.hellgate.*
 import io.hellgate.android.sdk.client.hellgate.NextAction
-import io.hellgate.android.sdk.element.additionaldata.AdditionalDataTypes
 import io.hellgate.android.sdk.model.CardData
 import io.hellgate.android.sdk.model.TokenizeCardResponse
 import io.hellgate.android.sdk.util.jsonDeserialize
@@ -38,7 +37,6 @@ class TokenServiceKtTest {
                 override suspend fun completeTokenizeCard(
                     sessionId: String,
                     encryptedData: String,
-                    additionalData: Map<AdditionalDataTypes, String>,
                 ): Either<HttpClientError, SessionResponse> = SessionResponse(SessionResponse.Data.TokenId(tokenId), null, "success").right()
 
                 override fun close() = Unit
@@ -58,7 +56,6 @@ class TokenServiceKtTest {
                 override suspend fun completeTokenizeCard(
                     sessionId: String,
                     encryptedData: String,
-                    additionalData: Map<AdditionalDataTypes, String>,
                 ): Either<HttpClientError, SessionResponse> = HttpClientError("Error").left()
 
                 override fun close() = Unit
@@ -79,7 +76,6 @@ class TokenServiceKtTest {
                 override suspend fun completeTokenizeCard(
                     sessionId: String,
                     encryptedData: String,
-                    additionalData: Map<AdditionalDataTypes, String>,
                 ): Either<HttpClientError, SessionResponse> =
                     HttpClientError("Error").left()
 
@@ -102,7 +98,6 @@ class TokenServiceKtTest {
                 override suspend fun completeTokenizeCard(
                     sessionId: String,
                     encryptedData: String,
-                    additionalData: Map<AdditionalDataTypes, String>,
                 ): Either<HttpClientError, SessionResponse> =
                     HttpClientError("Error").left()
 
@@ -126,7 +121,6 @@ class TokenServiceKtTest {
                 override suspend fun completeTokenizeCard(
                     sessionId: String,
                     encryptedData: String,
-                    additionalData: Map<AdditionalDataTypes, String>,
                 ): Either<HttpClientError, SessionResponse> =
                     SessionResponse(null, null, "success").right()
 


### PR DESCRIPTION
To ensure that guardian also receives the additional data it needs to be encrypted in the jwe

close #7
